### PR TITLE
ST3 compatability

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -39,7 +39,7 @@ def brew(args, source):
         args.append("-s")
     else:
         args.append("-e")
-    return run("coffee", args=args, source=source)
+    return run("coffee", args=args, source=source.encode('utf-8'))
 
 
 def cake(task, cwd):


### PR DESCRIPTION
The print statements are missing parentheses and stopping the code from working in ST3. I've just run 2to3 on CoffeeScripy.py. Not sure how to test plugins, so is untested :-)

``` python
reloading plugin sublime-better-coffeescript.CoffeeScript
Traceback (most recent call last):
  File "/opt/sublime_text/sublime_plugin.py", line 72, in reload_plugin
    m = importlib.import_module(modulename)
  File "X/importlib/__init__.py", line 88, in import_module
  File "<frozen importlib._bootstrap>", line 1577, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1558, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1525, in _find_and_load_unlocked
  File "/home/donovan/.config/sublime-text-3/Installed Packages/sublime-better-coffeescript.sublime-package/CoffeeScript.py", line 91
    print "Compile dir specified: " + compile_dir
```
