### PR TITLE
Coffee doesn't work when parameter is an absolute path in windows

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -17,6 +17,11 @@ def run(cmd, args=[], source="", cwd=None, env=None):
     if not type(args) is list:
         args = [args]
     if sys.platform == "win32":
+        source_file = args[-1]
+        if path.isfile(source_file):
+          source_dir, source_file = path.split(source_file)
+          args[-1] = source_file
+          cmd = "cd /D " + source_dir + " && " + cmd
         proc = Popen([cmd] + args, env=env, cwd=cwd, stdout=PIPE, stdin=PIPE, stderr=PIPE, shell=True)
         stat = proc.communicate(input=source.encode('utf-8'))
     else:


### PR DESCRIPTION
Coffee compile was not working, since coffee has a problem with absolute paths in windows (Windows 7 x64 with Node.js Installer). I wrote a fix which first changes to the target directory and calls the coffee command with only the filename. Now compile is working.
