### PR TITLE
Better `Run` commands

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -19,9 +19,9 @@ def run(cmd, args=[], source="", cwd=None, env=None):
     if sys.platform == "win32":
         source_file = args[-1]
         if path.isfile(source_file):
-          source_dir, source_file = path.split(source_file)
-          args[-1] = source_file
-          cmd = "cd /D " + source_dir + " && " + cmd
+            source_dir, source_file = path.split(source_file)
+            args[-1] = source_file
+            cmd = "cd /D " + source_dir + " && " + cmd
         proc = Popen([cmd] + args, env=env, cwd=cwd, stdout=PIPE, stdin=PIPE, stderr=PIPE, shell=True)
         stat = proc.communicate(input=source.encode('utf-8'))
     else:
@@ -118,7 +118,7 @@ class CompileCommand(TextCommand):
         sublime.status_message(status)
 
         # leave 'save message' visible for 300ms
-        later = lambda: sublime.status_message(status);
+        later = lambda: sublime.status_message(status)
         sublime.set_timeout(later, 300)
 
 
@@ -159,7 +159,7 @@ class CheckSyntaxCommand(TextCommand):
         sublime.status_message('Syntax %s' % status)
 
 
-class RunScriptCommand(WindowCommand):
+class QuickRunBarCommand(WindowCommand):
     def finish(self, text):
         if text == '':
             return
@@ -175,13 +175,7 @@ class RunScriptCommand(WindowCommand):
             sublime.status_message('Syntax %s' % res["err"].split("\n")[0])
 
     def run(self):
-        sel = Text.sel(sublime.active_window().active_view())
-        if len(sel) > 0:
-            if not isCoffee():
-                return
-            self.finish(sel)
-        else:
-            self.window.show_input_panel('Coffee >', '', self.finish, None, None)
+        self.window.show_input_panel('Coffee >', '', self.finish, None, None)
 
 
 class RunCakeTaskCommand(WindowCommand):
@@ -336,7 +330,7 @@ def isView(view_id):
     if not view_id:
         return False
     window = sublime.active_window()
-    view = window.active_view() if window != None else None
+    view = window.active_view() if window is not None else None
     return (view is not None and view.id() == view_id)
 
 
@@ -405,9 +399,9 @@ class CaptureEditing(sublime_plugin.EventListener):
             print "Compiling on save..."
             view.run_command("compile")
         show_compile_output_on_save = settings.get('showOutputOnSave', True)
-        if show_compile_output_on_save is True and isCoffee() is True and CompileOutput.IS_OPEN is True:
+        if show_compile_output_on_save is True and isCoffee() is True and RunScriptCommand.PANEL_IS_OPEN is True:
             print "Updating output panel..."
-            view.run_command("compile_output")
+            view.run_command("run_script")
 
         return
 
@@ -434,9 +428,9 @@ class CaptureEditing(sublime_plugin.EventListener):
         return
 
 
-class CompileOutput(TextCommand):
+class RunScriptCommand(TextCommand):
     PANEL_NAME = 'coffee_compile_output'
-    IS_OPEN = False
+    PANEL_IS_OPEN = False
 
     def is_enabled(self):
         return isCoffee(self.view)
@@ -473,5 +467,5 @@ class CompileOutput(TextCommand):
         output.set_read_only(True)
 
         window.run_command('show_panel', {'panel': 'output.%s' % self.PANEL_NAME})
-        self.IS_OPEN = True
+        self.PANEL_IS_OPEN = True
         return

--- a/CoffeeScript.sublime-commands
+++ b/CoffeeScript.sublime-commands
@@ -4,8 +4,8 @@
 	,	"command": "check_syntax"
 	}
 ,	{
-		"caption": "Coffee: Run Script"
-	,	"command": "run_script"
+		"caption": "Coffee: Quick Run Bar"
+	,	"command": "quick_run_bar"
 	}
 ,	{
 		"caption": "Coffee: Run Cake Task"
@@ -32,11 +32,7 @@
 	,	"command": "toggle_watch"
 	}
 ,	{
-		"caption": "Coffee: Toggle Output Panel"
-	,	"command": "toggle_output_panel"
-	}
-,	{
-		"caption": "Coffee: Show Compiled"
-	,	"command": "compile_output"
+		"caption": "Coffee: Run Script / Selection"
+	,	"command": "run_script"
 	}
 ]

--- a/Menu/Context.sublime-menu
+++ b/Menu/Context.sublime-menu
@@ -1,3 +1,6 @@
 [
-    { "command": "compile_output" }
+    {
+      "command": "run_script",
+      "caption": "Run Script / Selection"
+    }
 ]


### PR DESCRIPTION
> **TL;DR**:
> I found `Show Compiled` and `Run Script` a bit confusing. Let's rename them to `Run Script / Selection` and `Quick Run Bar` (respectively) and try to make them easier to understand.

Hope I'm not kicking any shins by saying this, but I found `Run Script` and `Show Compiled` a bit confusing: they have sort-a kinda the same functionality (i.e. compile and run code) and they're awkwardly named.

This is what they currently do:
- `Show Compiled` compiles and runs the current file or selection (if any), and outputs the results (or errors) to the Console panel.
- `Run Script` (<kbd>alt</kbd>+<kbd>shift</kbd>+<kbd>r</kbd>) compiles and runs code and outputs the result to a new file. If there is a selection, `Run Script` will run the selection. If there's **no** selection, it shows what can be described as a 'Quick Run bar', and runs the code you enter into it.

What confused me:
- `Show Compiled` does **exactly** what I expected `Run Script` to do.
- `Show Compiled` sounds like an alias for `Display JavaScript`.
- I didn't realise `Run Script` could be run on selections until I looked at the code.

Here's what I'd like to propose:
- Rename `Show Compiled` to `Run Script / Selection` and give it `Run Script`'s shortcut. (Users that prefered the old keymap can always override it.)
- Rename `Run Script` to `Quick Run Bar` and ditch the selection handling.
- Have `Quick Run Bar` output into the current file (at the caret position), instead of a new file. (And possibly make this behaviour configurable.)

What do you think?
