### PR TITLE
type # for #{}

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -3,8 +3,7 @@
 		[
 			{ "key": "setting.auto_match_enabled", "operator": "equal", "operand": true },
 			{
-				// "operand": "(string.quoted.double.ruby | string.interpolated.ruby) - string source",
-				"operand": true,
+				"operand": "(string.quoted.double | string.interpolated) - string source",
 				"operator": "equal",
 				"match_all": true,
 				"key": "selector"


### PR DESCRIPTION
hi,
I copied this file from the default Ruby package and did a small tweak.
typing # within a double quotation marks would be interpolated into #{} as it normally does in Ruby.
typing # by itself or within single quotation marks would do nothing.
