### PR TITLE
Source maps support

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -25,7 +25,7 @@ def settings_get(name, default=None):
     # the project_settings would return None (?)
     if project_settings is None:
         project_settings = {}
-        
+
     setting = project_settings.get(name, plugin_settings.get(name, default))
     return setting
 
@@ -113,6 +113,7 @@ class CompileCommand(TextCommand):
         source_dir = os.path.normcase(os.path.dirname(source_file))
         relative_div = settings_get('relativeDir')
         relative_div = os.path.normcase(relative_div) if relative_div else False
+        sourcemaps = settings_get('sourceMaps', True)
 
         # print "Compiling: " + source_file
         # if sys.platform == "win32":
@@ -121,6 +122,8 @@ class CompileCommand(TextCommand):
         args = ['-c', source_file]
         if no_wrapper:
             args = ['-b'] + args
+        if sourcemaps:
+            args = ['-m'] + args
         if compile_dir and (isinstance(compile_dir, str) or isinstance(compile_dir, unicode)):
             print("Compile dir specified: " + compile_dir)
             # Check for absolute path or relative path for compile_dir

--- a/CoffeeScript.sublime-settings
+++ b/CoffeeScript.sublime-settings
@@ -44,7 +44,7 @@
 		## Enable compiling to a specific directory.
 		#### Description
 
-		if it is a string like 'some/directory' then `-o some/directory` will be added to `coffee` compiler. 
+		if it is a string like 'some/directory' then `-o some/directory` will be added to `coffee` compiler.
 		if it is false or not string then it will compile your `script.coffee` to the directory it is in.
 
 		#### Example:
@@ -52,7 +52,7 @@
 			compileDir": "out"
 		Directory is absolute if specified such as
 			compileDir": "/home/logan/Desktop/out"
-		
+
 	*/
 ,	"compileDir": false
 	/*
@@ -67,9 +67,17 @@
 		So
 			"/home/user/projects/coffee/app.coffee" will compile to "/home/user/projects/js/app.js"
 			"/home/user/projects/coffee/models/prod.coffee" will compile to "/home/user/projects/js/models/prod.js"
-		
+
 	*/
 ,	"relativeDir": false
+
+	/*
+		## Enable source maps support
+  		CoffeeScript 1.6.1 and above include support for better coffeescript debugging.
+  		Browsers that support it can trace your bugs to your original coffeescript source code,
+  		instead of the javascript that's being evalutated
+	*/
+, "sourceMaps":false
 
 
 }


### PR DESCRIPTION
hi, 
  CoffeeScript 1.6.1 and above include support for better coffeescript debugging.
i've made two small changes that enable this
cheers!
