### PR TITLE
Add Float(32|64)Array to support.class.coffee

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -434,7 +434,8 @@
 		<dict>
 			<key>match</key>
 			<string>(?x)\b(
-				Array|ArrayBuffer|Blob|Boolean|Date|document|event|Function|
+				Array|ArrayBuffer|Blob|Boolean|Date|document
+				|event|Float(32|64)Array|Function|
 				Int(8|16|32|64)Array|Math|Map|Number|
 				Object|Proxy|RegExp|Set|String|WeakMap|
 				window|Uint(8|16|32|64)Array|XMLHttpRequest


### PR DESCRIPTION
This causes `Float32Array` and `Float64Array` to be highlighted in the same fashion as `Int8Array`, `Uint16Array`, etc.
