### PR TITLE
Tweak build system for windows

### DIFF
--- a/CoffeeScript.sublime-build
+++ b/CoffeeScript.sublime-build
@@ -1,12 +1,15 @@
-{
-	"cmd": ["cake", "sbuild"]
+{	"cmd": ["cake", "sbuild"]
 ,	"path": "/usr/local/bin:$PATH"
 ,	"selector": "source.coffee"
 ,	"working_dir": "$project_path"
+
+,	"windows":
+	{	"path": "$PATH"
+	,	"cmd": ["cake.cmd", "sbuild"]
+	}
+
 ,	"variants":
-	[
-		{
-			"name": "Run",
+	[	{	"name": "Run",
 			"cmd": ["coffee", "$file"]
 		}
 	]


### PR DESCRIPTION
It can't find `cake`, even though it's on PATH - as `cake.cmd` though, so I added `.cmd` to it. `"shell": true` would also do it, if you prefer this.

And while I was editing it I also noticed the path override which obviously does not work on Windows.

Sadly, running `cake` still files a huge traceback for me, but that's a different thing.
