### PR TITLE
[alt+shift+w] keymap conflict

### DIFF
--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -6,6 +6,6 @@
 ,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
 ,	{"keys": ["alt+shift+l"], "command": "compile_and_display", "args": {"opt": "-t"}}
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
+,	{"keys": ["alt+shift+down"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -6,6 +6,6 @@
 ,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
 ,	{"keys": ["alt+shift+x"], "command": "compile_and_display", "args": {"opt": "-t"}}
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
+,	{"keys": ["alt+shift+down"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -6,6 +6,6 @@
 ,	{"keys": ["alt+shift+d"], "command": "compile_and_display", "args": {"opt": "-p"}}
 ,	{"keys": ["alt+shift+l"], "command": "compile_and_display", "args": {"opt": "-t"}}
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
-,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
+,	{"keys": ["alt+shift+down"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
 ]


### PR DESCRIPTION
Hi,

You have a keymap defined, concretely **"toggle_watch"**, that conflicts with one that is already defined in the Sublime Text default keymaps: **"insert_snippet"**.

I think that **[alt+shift+down]** may be a good alternative...

Thanks!
