### PR TITLE
conflict with LaTeX

### DIFF
--- a/Symbol List.tmPreferences
+++ b/Symbol List.tmPreferences
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>Symbol List</string>
     <key>scope</key>
-    <string>source.coffee meta.class.coffee,source.coffee meta.function</string>
+    <string>source.coffee meta.class.coffee,source.coffee meta.function.coffee</string>
     <key>settings</key>
     <dict>
         <key>showInSymbolList</key>


### PR DESCRIPTION
Otherwise it put things like `\begin{equation}` in LaTeX symbols list, even when syntax is set to LaTeX.

See https://github.com/SublimeText/LaTeXTools/issues/325 (originally I though that it was an issue with LaTeXTools, but it wasn't).
