### PR TITLE
Build improvements: npm in $PATH, file_regex

### DIFF
--- a/CoffeeScript.sublime-build
+++ b/CoffeeScript.sublime-build
@@ -1,6 +1,6 @@
 {
     "cmd": ["cake", "sbuild"],
-    "path": "/usr/local/bin:$PATH",
+    "path": "/usr/local/bin:/usr/local/share/npm/bin:$PATH",
     "selector": "source.coffee",
     "working_dir": "$project_path"
 
@@ -13,6 +13,7 @@
     ,
     "variants": [{
         "name": "Run",
+        "file_regex": "^[ ]*at .*?(/...*?\\.coffee):([0-9]*):.*",
         "cmd": ["coffee", "$file"]
     }]
 }


### PR DESCRIPTION
The reason for first commit is that now Sublime auto-indents `.sublime_build` files on save, and it looks like there's no way to turn this off. I can submit a PR without changed indents if that helps.
