### PR TITLE
Indent/dedent 'else if'

### DIFF
--- a/Indent.tmPreferences
+++ b/Indent.tmPreferences
@@ -9,7 +9,7 @@
 	<key>settings</key>
 	<dict>
 		<key>decreaseIndentPattern</key>
-		<string>^\s*(\}|\]|else|catch|finally)$</string>
+		<string>^\s*(\}|\]|else|catch|finally|else\s+if\s+\S.*)$</string>
 		<key>increaseIndentPattern</key>
 		<string>(?x)
 		^\s*
@@ -17,7 +17,7 @@
 		|[a-zA-Z\$_](\w|\$|:|\.)*\s*(?=\:(\s*\(.*\))?\s*((=|-)&gt;\s*$)) # function that is not one line
 		|[a-zA-Z\$_](\w|\$|\.)*\s*(:|=)\s*((if|while)(?!.*?then)|for|$) # assignment using multiline if/while/for
 		|(if|while|unless)\b(?!.*?then)|(for|switch|when|loop)\b
-		|(else|try|finally|catch\s+\S.*)\s*$
+		|(else|try|finally|catch\s+\S.*|else\s+if\s+\S.*)\s*$
 		|.*[-=]&gt;$
 		|.*[\{\[]$)</string>
 	</dict>


### PR DESCRIPTION
Hi,

A quick change to support the automatic indentation de-indentation of 'else if <...>' lines.

-Martin
