### PR TITLE
Fix the '--csv is deprecated' warning

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -317,7 +317,7 @@ class LintCommand(TextCommand):
 
     def run(self, edit):
         filepath = self.view.file_name()
-        args = [filepath, "--csv"]
+        args = [filepath, "--reporter csv"]
         lintConfFile = settings_get("lintConfFile", False)
         if lintConfFile:
             if not path.isfile(lintConfFile):


### PR DESCRIPTION
Fixes the (linter?) warning about how `--csv` is deprecated and `--reporter csv` should be used instead.
![screen shot 2014-05-29 at 16 11 25](https://cloud.githubusercontent.com/assets/4263831/3119966/d264bc26-e74b-11e3-9cac-359654549457.png)
