### PR TITLE
Add support for interpolated_coffee within underscore templates (<% %>)

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -640,7 +640,9 @@
 				</dict>
 			</array>
 		</dict>
-		<key>interpolated_coffee</key>
+
+
+ 		<key>interpolated_coffee</key>
 		<dict>
 			<key>patterns</key>
 			<array>
@@ -667,8 +669,33 @@
 						</dict>
 					</array>
 				</dict>
+
+				<dict>
+					<key>begin</key>
+					<string>&lt;%</string>
+					<key>captures</key>
+					<dict>
+						<key>0</key>
+						<dict>
+							<key>name</key>
+							<string>punctuation.section.embedded.coffee</string>
+						</dict>
+					</dict>
+					<key>end</key>
+					<string>%&gt;</string>
+					<key>name</key>
+					<string>source.coffee.embedded.source</string>
+					<key>patterns</key>
+					<array>
+						<dict>
+							<key>include</key>
+							<string>$self</string>
+						</dict>
+					</array>
+				</dict>
 			</array>
 		</dict>
+
 		<key>numeric</key>
 		<dict>
 			<key>patterns</key>


### PR DESCRIPTION
I added support for interpolated coffeescript code within underscore templates (<% %>).

Before:
![without_interpolation](https://cloud.githubusercontent.com/assets/2486553/3209257/7cf7ff18-ee63-11e3-9ee9-f460103cd3c4.jpg)

After:
![with_interpolation](https://cloud.githubusercontent.com/assets/2486553/3209258/7e602628-ee63-11e3-85cb-7b01086106fb.jpg)

Unfortunately, in order to make it work, the user has to modify his tmTheme (unless, the theme was already modified).

For those who are interested, the necessary additions for the Monokai theme are:

```
        <dict>
            <key>name</key>
                    <string>Embedded Punctuation</string>
            <key>scope</key>
                    <string>string punctuation.section.embedded</string>
            <key>settings</key>
            <dict>
                    <key>foreground</key>
                    <string>#F92672</string>
            </dict>
        </dict>

        <dict>
            <key>name</key>
                    <string>Embedded CoffeeScript Source</string>
            <key>scope</key>
                    <string>string source.coffee.embedded.source</string>
            <key>settings</key>
            <dict>
                    <key>foreground</key>
                    <string>#FFFBF7</string>
            </dict>
        </dict>

        <dict>
            <key>name</key>
                    <string>Strings in Embedded CoffeeScript Source</string>
            <key>scope</key>
                    <string>string source.coffee.embedded.source string</string>
            <key>settings</key>
            <dict>
                    <key>foreground</key>
                    <string>#E6DB74</string>
            </dict>
        </dict>
```
