### PR TITLE
Added subclass snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Context menu has `Compile Output` that compiles the current CoffeeScript and out
 **Classes**
 
 	Class - cla
+	Class extends SuperClass - clx
 
 **Other**
 

--- a/Snippets/Class (extension).tmSnippet
+++ b/Snippets/Class (extension).tmSnippet
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>content</key>
+  <string>class ${1:Name} extends ${2:SuperClass}
+  ${3:constructor: ${4:(${5:arguments}) }-&gt;
+    ${6:# ...}}
+  $7
+$0</string>
+  <key>name</key>
+  <string>Class (extension)</string>
+  <key>scope</key>
+  <string>source.coffee</string>
+  <key>tabTrigger</key>
+  <string>clx</string>
+</dict>
+</plist>


### PR DESCRIPTION
There are a few really useful snippets I use in my day-to-day work that I thought I should offer to others. This is one of them. 

Typing `clx` will replace to `class Name extends SuperClass` along with the constructor boilerplate included in the `cla` snippet.
