### PR TITLE
Quick add/remove parens around function args.

### DIFF
--- a/CoffeeScript.sublime-commands
+++ b/CoffeeScript.sublime-commands
@@ -43,4 +43,12 @@
 		"caption": "Coffee: Lint"
 	,	"command": "lint"
 	}
+, {
+		"caption": "Coffee: Add Parens"
+	,	"command": "add_parens"
+	}
+, {
+		"caption": "Coffee: Remove Parens"
+	,	"command": "remove_parens"
+	}
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -8,4 +8,8 @@
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
 ,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+,	{"keys": ["alt+shift+p", "a"], "command": "add_parens"}
+,	{"keys": ["alt+shift+p", "r"], "command": "remove_parens"}
+,	{"keys": ["("], "command": "add_parens", "context": [{ "key": "selector", "operator": "equal", "operand": "source.coffee" }]}
+,	{"keys": ["super+shift+9"], "command": "remove_parens", "context": [{ "key": "selector", "operator": "equal", "operand": "source.coffee" }]}
 ]


### PR DESCRIPTION
![coffee](https://cloud.githubusercontent.com/assets/3876443/3819389/3bfbfed2-1cea-11e4-94c6-e3f2e6f39a69.gif)

Added to Command List, and as keybinds.

Overrides default sublime paren-wrapping behavior when the selection starts immediately after a space. Open to debate re: the keys used in keybindings.
