### PR TITLE
Remove the left parenthesis key map

### DIFF
--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -10,6 +10,5 @@
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
 ,	{"keys": ["alt+shift+p", "a"], "command": "add_parens"}
 ,	{"keys": ["alt+shift+p", "r"], "command": "remove_parens"}
-,	{"keys": ["("], "command": "add_parens", "context": [{ "key": "selector", "operator": "equal", "operand": "source.coffee" }]}
 ,	{"keys": ["super+shift+9"], "command": "remove_parens", "context": [{ "key": "selector", "operator": "equal", "operand": "source.coffee" }]}
 ]


### PR DESCRIPTION
Fixes issue https://github.com/aponxi/sublime-better-coffeescript/issues/169.

Essentially removing the key binding on the left parenthesis, as people said it isn't a needed addition to this plugin nor was it even shared to the other platforms key bindings anyway, just OSX.
