### PR TITLE
Replace add/remove_parens with toggle_parens.

### DIFF
--- a/CoffeeScript.sublime-commands
+++ b/CoffeeScript.sublime-commands
@@ -44,11 +44,7 @@
 	,	"command": "lint"
 	}
 , {
-		"caption": "Coffee: Add Parens"
-	,	"command": "add_parens"
-	}
-, {
-		"caption": "Coffee: Remove Parens"
-	,	"command": "remove_parens"
+		"caption": "Coffee: Toggle Parens"
+	,	"command": "toggle_parens"
 	}
 ]

--- a/Keymaps/Default (Linux).sublime-keymap
+++ b/Keymaps/Default (Linux).sublime-keymap
@@ -8,4 +8,5 @@
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
 ,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+,	{"keys": ["alt+shift+9"], "command": "toggle_parens"}
 ]

--- a/Keymaps/Default (OSX).sublime-keymap
+++ b/Keymaps/Default (OSX).sublime-keymap
@@ -8,7 +8,5 @@
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
 ,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
-,	{"keys": ["alt+shift+p", "a"], "command": "add_parens"}
-,	{"keys": ["alt+shift+p", "r"], "command": "remove_parens"}
-,	{"keys": ["super+shift+9"], "command": "remove_parens", "context": [{ "key": "selector", "operator": "equal", "operand": "source.coffee" }]}
+,	{"keys": ["alt+shift+9"], "command": "toggle_parens"}
 ]

--- a/Keymaps/Default (Windows).sublime-keymap
+++ b/Keymaps/Default (Windows).sublime-keymap
@@ -8,4 +8,5 @@
 ,	{"keys": ["alt+shift+n"], "command": "compile_and_display", "args": {"opt": "-n"}}
 ,	{"keys": ["alt+shift+w"], "command": "toggle_watch"}
 ,	{"keys": ["alt+shift+z"], "command": "toggle_output_panel"}
+,	{"keys": ["alt+shift+9"], "command": "toggle_parens"}
 ]

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ You can access the commands either using the command palette (`ctrl+shift+P` or 
 	alt+shift+n - Display parser nodes
 	alt+shift+w - Toggle watch mode
 	alt+shift+p - Toggle output panel
+	alt+shift+9 - Toggle parens around function arguments
 
 
 Context menu has `Compile Output` that compiles the current CoffeeScript and outputs the javascript code that is run, in a panel.


### PR DESCRIPTION
![coffee](https://cloud.githubusercontent.com/assets/3876443/4013617/48a3b126-2a18-11e4-827d-c9cb6d4d3e7f.gif)

With this, parens are removed if your cursor selection is empty, and added if you have a selection. **I don't think this is the most intuitive way to toggle.** But I'm not sure there's a better way to determine whether arguments are parenthesized or un-parenthesized. The best solution might be to add a syntax-highlight definition that would match function arguments and differentiate between those in parens and those outside of parens. This is beyond my regex abilities currently.
