### PR TITLE
Don't run coffee with -m option if source maps disabled

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -493,10 +493,13 @@ class Watcher():
         self.outputFilePath = path.join(self.outputTempDir, self.outputFileName)
 
         no_wrapper = settings_get('noWrapper', True)
+        sourcemaps = settings_get('sourceMaps', True)
         args = []
         if no_wrapper:
             args = ['-b'] + args
-        args = args + ["-m", "-o", self.outputTempDir, self.sourceFilePath]
+        if sourcemaps:
+            args = args + ['-m']
+        args = args + ["-o", self.outputTempDir, self.sourceFilePath]
 
         res = run("coffee", args)
         if not res["okay"]:
@@ -513,7 +516,10 @@ class Watcher():
 
     def refresh(self):
         no_wrapper = settings_get('noWrapper', True)
-        args = ["-m", "-o", self.outputTempDir]
+        sourcemaps = settings_get('sourceMaps', True)
+        args = ["-o", self.outputTempDir]
+        if sourcemaps:
+            args = ['-m'] + args
         if no_wrapper:
             args = ['-b'] + args
         res = brew(args, source=Text.get(self.inputView))


### PR DESCRIPTION
Can you have a look at this and see if it will work? Thanks! It should make the plugin work with older versions of the Coffeescript compiler, which don't support source maps.

Fixes #185.
