### PR TITLE
Fixed string.regexp.coffee again

### DIFF
--- a/CoffeeScript.tmLanguage
+++ b/CoffeeScript.tmLanguage
@@ -217,7 +217,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>/(?![\s=/*+{}?]).*?([^\\]|\\\\)/[igmy]{0,4}(?![a-zA-Z0-9])</string>
+			<string>/(?![\s=/*+{}?])(\\.|.)*?/[igmy]{0,4}(?![a-zA-Z0-9])</string>
 			<key>name</key>
 			<string>string.regexp.coffee</string>
 		</dict>

--- a/CoffeeScript_Literate.tmLanguage
+++ b/CoffeeScript_Literate.tmLanguage
@@ -746,7 +746,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>/(?![\s=/*+{}?]).*?[^\\]/[igmy]{0,4}(?![a-zA-Z0-9])</string>
+					<string>/(?![\s=/*+{}?])(\\.|.)*?/[igmy]{0,4}(?![a-zA-Z0-9])</string>
 					<key>name</key>
 					<string>string.regexp.coffee</string>
 				</dict>


### PR DESCRIPTION
This was still broken after the fix in #174. This change simply copies the working regex.string.coffee from the literate tmLang.
![Broken](https://photos-6.dropbox.com/t/1/AACP-WN5bITFzA95RLsH2uvNZ-HV0FT8TbLpDLtsYKd6gA/12/14759638/png/1024x768/3/1411758000/0/2/Screenshot%202014-09-26%2010.03.42.png/GS2q4XiWI4rk5_mux7MhKqQ524qNzaQZd4SYXEtctvo)

![working](https://photos-5.dropbox.com/t/1/AAAOQBGh9Q0s0OFhg1m6954snA8qIunY9awM6uNVdLsOuw/12/14759638/png/1024x768/3/1411758000/0/2/Screenshot%202014-09-26%2010.11.41.png/6MaPzqTo6jIq7VVqkbnvXEugF_A0ngza39FtReD0oyI)
