### PR TITLE
Improve the placement of watched output.

### DIFF
--- a/CoffeeScript.py
+++ b/CoffeeScript.py
@@ -477,15 +477,33 @@ class Watcher():
         self.created_pane = False
         self.inputView = inputView
         print("Now watching " + watched_filename(inputView))
-        if self.inputView.window().num_groups() == 1:
-            # create new column
+        self.determine_output_pane()
+        self.create_output()
+
+    def determine_output_pane(self):
+        active_group = self.inputView.window().active_group()
+        num_groups = self.inputView.window().num_groups()
+        layout = self.inputView.window().get_layout()
+        cells = layout['cells']
+        cols = layout['cols']
+
+        if num_groups == 1:
+            # only pane. create a new one.
+            self.output_pane_index = 1
+            self.created_pane = True
             self.inputView.window().run_command('set_layout', {
                 "cols": [0.0, 0.5, 1.0],
                 "rows": [0.0, 1.0],
                 "cells": [[0, 0, 1, 1], [1, 0, 2, 1]]
             })
-            self.created_pane = True
-        self.create_output()
+        elif active_group == num_groups - 1:
+            # last pane in window. output to the previous one.
+            self.output_pane_index = active_group - 1
+        elif len(cols) > 2 and cells[active_group][2] == len(cols) - 1:
+            # last pane in row. output to previous one.
+            self.output_pane_index = active_group - 1
+        else:
+            self.output_pane_index = active_group + 1
 
     def create_output(self):
         self.sourceFilePath = self.inputView.file_name()
@@ -511,7 +529,7 @@ class Watcher():
         # create new tab
         self.outputView = self.inputView.window().open_file(self.outputFilePath)
         # move it to second column
-        self.outputView.window().focus_group(1)
+        self.outputView.window().focus_group(self.output_pane_index)
         self.outputView.window().set_view_index(self.outputView, self.outputView.window().active_group(), 0)
         # self.outputView.window().focus_group(0)
         self.inputView.window().focus_view(self.inputView)
@@ -556,7 +574,7 @@ class Watcher():
             window.focus_view(self.outputView)
             window.run_command("close")
 
-        if self.created_pane and len(window.views_in_group(1)) == 0:
+        if self.created_pane and len(window.views_in_group(self.output_pane_index)) == 0:
             window.run_command('set_layout', {
                 "cols": [0.0, 1.0],
                 "rows": [0.0, 1.0],


### PR DESCRIPTION
According to the basic rules: 
With 2 panes, always put the compiled JS in the _other_ pane.
With more than 2 panes, put the compiled JS to the right (or below), unless there is no pane to the right (or below).

More detailed rules:
With the following **Layouts**, with the following **Input** panes selected, **Output** will appear in...

| Layout | Input | Output |
| --- | --- | --- |
| 1x1 | Only pane | New column to the right |
| 2x1 | Left | Right |
| 2x1 | Right | Left |
| 1x2 | Top | Bottom |
| 1x2 | Bottom | Top |
| 3x1 | Left | Middle |
| 3x1 | Middle | Right |
| 3x1 | Right | Middle |
| 4x1 | Left | Mid-Left |
| 4x1 | Mid-Left | Mid-Right |
| 4x1 | Mid-Right | Right |
| 4x1 | Right | Mid-Right |
| 2x2 | Top-Left | Top-Right |
| 2x2 | Top-Right | Top-Left |
| 2x2 | Bottom-Left | Bottom-Right |
| 2x2 | Bottom-Right | Bottom-Left |

Closes #182 
