### PR TITLE
Fix highlighting of `constructor` function if `class` is nameless

### DIFF
--- a/CoffeeScript.sublime-syntax
+++ b/CoffeeScript.sublime-syntax
@@ -102,6 +102,8 @@ contexts:
         - class-name
 
   class-name:
+    - match: $
+      pop: 1
     - match: (?=extends\b)
       pop: 1
     - match: ({{identifier}})(\.)

--- a/tests/syntax_test_scope.coffee
+++ b/tests/syntax_test_scope.coffee
@@ -67,6 +67,11 @@ class App.Router extends Snakeskin.Router
 #                                 ^ punctuation.accessor.dot.coffee
 #                                  ^^^^^^ entity.other.inherited-class.coffee
 
+class
+# <- meta.class.coffee keyword.declaration.class.coffee
+  constructor: ->
+# ^ meta.function.identifier.coffee entity.name.function.coffee
+
 ###[ FUNCTIONS ]###############################################################
 
   name:


### PR DESCRIPTION
before
<img width="175" height="111" alt="image" src="https://github.com/user-attachments/assets/058dcdcb-0cec-461f-aeff-1e89a45dd13e" />

after
<img width="172" height="53" alt="image" src="https://github.com/user-attachments/assets/e1ff9b1a-7e29-466d-b079-2b9dfd2271b5" />
